### PR TITLE
Fixed mount_be stdout.

### DIFF
--- a/bectl.py
+++ b/bectl.py
@@ -74,6 +74,7 @@ def mount_be(be_name: str, path: str = None) -> str:
     cmd_list.append(path) if path else None
     bectl_process = run(
         cmd_list,
+        stdout=PIPE,
         universal_newlines=True,
         encoding='utf-8'
     )


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug in the mount_be function by ensuring that the stdout of the subprocess is captured.

- **Bug Fixes**:
    - Fixed the issue where the stdout of the mount_be function was not being captured.

<!-- Generated by sourcery-ai[bot]: end summary -->